### PR TITLE
fix: 解决webpack打包时候babel了node_module下包

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -52,7 +52,7 @@ export default (env = {}) => {
 				{
 					test: /\.js$/,
 					include: /src/,
-					exclude: /\/node_modules\//,
+					exclude: /node_modules/,
 					use: [
 						'babel-loader',
 						shouldLint && 'eslint-loader',
@@ -61,7 +61,7 @@ export default (env = {}) => {
 				{
 					test: /\.wxs$/,
 					include: /src/,
-					exclude: /\/node_modules\//,
+					exclude: /node_modules/,
 					use: [
 						...relativeFileLoader(),
 						'babel-loader',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -52,6 +52,7 @@ export default (env = {}) => {
 				{
 					test: /\.js$/,
 					include: /src/,
+					exclude: /\/node_modules\//,
 					use: [
 						'babel-loader',
 						shouldLint && 'eslint-loader',
@@ -60,6 +61,7 @@ export default (env = {}) => {
 				{
 					test: /\.wxs$/,
 					include: /src/,
+					exclude: /\/node_modules\//,
 					use: [
 						...relativeFileLoader(),
 						'babel-loader',


### PR DESCRIPTION
存在`babel-loader`的`rule`中加入配置项 `exclude: /\/node_modules\//`  
issue: https://github.com/cantonjs/wxapp-boilerplate/issues/16